### PR TITLE
Development

### DIFF
--- a/assets/js/builder.js
+++ b/assets/js/builder.js
@@ -34,6 +34,7 @@
         if(offsetFix){
           ui.item.css('margin-top', 0);
         }
+        app.content.reload();
       },
       helper: function(e, ui) {
         ui.children().each(function() {
@@ -52,7 +53,6 @@
         $.post(api, {ids: ids}, function() {
           app.content.reload();
         });
-
       }
     });
   };


### PR DESCRIPTION
Fix for small builder forms. We need to reload the content of the builder otherwise the width will be 0 and the form is very small.